### PR TITLE
`item` key in payload must be an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function notifyDashboard(options, data) {
 exports.TextWidgetValue = TextWidgetValue;
 function TextWidgetValue() {}
 TextWidgetValue.create = function(properties) {
-  return _.extend(new TextWidgetValue(), {item: properties});
+  return _.extend(new TextWidgetValue(), {item: [properties]});
 };
 
 exports.TravisCIEnv = TravisCIEnv;


### PR DESCRIPTION
Per the documentation, the `item` key in the JSON payload must be an array:

![geckoboard api docs 2015-02-23 16-45-31](https://cloud.githubusercontent.com/assets/45121/6332157/9c1679e8-bb7b-11e4-9765-31f1b6f5b2cb.png)
